### PR TITLE
Use a better return type for Annotate.

### DIFF
--- a/highlight.go
+++ b/highlight.go
@@ -159,10 +159,10 @@ func Print(s *scanner.Scanner, w io.Writer, p Printer) error {
 	return nil
 }
 
-func Annotate(src []byte, a Annotator) ([]*annotate.Annotation, error) {
+func Annotate(src []byte, a Annotator) (annotate.Annotations, error) {
 	s := NewScanner(src)
 
-	var anns []*annotate.Annotation
+	var anns annotate.Annotations
 	read := 0
 
 	tok := s.Scan()

--- a/highlight_test.go
+++ b/highlight_test.go
@@ -78,7 +78,7 @@ func TestAsHTML(t *testing.T) {
 
 func TestAnnotate(t *testing.T) {
 	src := []byte(`a:=2`)
-	want := []*annotate.Annotation{
+	want := annotate.Annotations{
 		{Start: 0, End: 1, Left: []byte(`<span class="pln">`), Right: []byte("</span>")},
 		{Start: 1, End: 2, Left: []byte(`<span class="pun">`), Right: []byte("</span>")},
 		{Start: 2, End: 3, Left: []byte(`<span class="pun">`), Right: []byte("</span>")},


### PR DESCRIPTION
This way, when the user uses that func:

``` Go
anns, err := syntaxhighlight.Annotate(...)

...

sort.Sort(anns)
```

They will not get this error:

```
# command-line-arguments
./main.go:215: cannot use anns (type []*annotate.Annotation) as type sort.Interface in argument to sort.Sort:
    []*annotate.Annotation does not implement sort.Interface (missing Len method)
```

Which of course the user can fix by converting the type themselves, but it'd be nicer if the API of `syntaxhighlight` is improved to avoid that problem. Hence this PR.

The `github.com/sourcegraph/annotate` package is already imported anyway, so there's no reason not to use its `Annotations` type.
