### PR TITLE
Try to fix Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - 1.3
+install:
+  - go get -d -t -v ./...
 script:
   - diff -u <(echo -n) <(gofmt -d ./)
   - go test -v -bench=. -benchmem


### PR DESCRIPTION
- I'm guessing that trying to write to benchmark.txt inside travis is likely creating the error due to permissions. Any file changes inside Travis will be lost anyway, so there's no point in doing that.
- Instead, I just opted to execute the test and benchmarks and show their output in Travis.
- Also make sure the Go code is `gofmt`ed.
- Use Go 1.3.
