### PR TITLE
Apply API improvements, unexport unneeded symbol.

### DIFF
--- a/keywords.go
+++ b/keywords.go
@@ -1,6 +1,6 @@
 package syntaxhighlight
 
-var Keywords = map[string]struct{}{
+var keywords = map[string]struct{}{
 	"BEGIN":            struct{}{},
 	"END":              struct{}{},
 	"False":            struct{}{},


### PR DESCRIPTION
- API improvements as described in #6.
- Unexport `keywords` map as it's not expected to be used by clients and is not documented. This makes the packages API slightly smaller and easier to use.
- Closes #6.

Unfortunately this requires a trivial change (improvement) for `Printer` and `Annotator` interfaces. Which required me to update my usages in a few packages, but it really took less than 3 minutes (by hand, in lieu of a better `go fix`-like solution :( ).

(Btw, I still don't have push rights here so I had to fork.)
