### PR TITLE
Add NilAnnotator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
 go:
-  - 1.3
+  - 1.4
 install:
-  - go get -d -t -v ./...
+  - go get golang.org/x/tools/cmd/vet
+  - go get -t -v ./...
 script:
   - diff -u <(echo -n) <(gofmt -d ./)
-  - go test -v -bench=. -benchmem
+  - go tool vet -composites=false ./
+  - go test -v -race -bench=. -benchmem ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ install:
   - go get -t -v ./...
 script:
   - diff -u <(echo -n) <(gofmt -d ./)
-  - go tool vet -composites=false ./
+  - go tool vet -composites=false ./*.go
+  - go tool vet -composites=false ./cmd/
   - go test -v -race -bench=. -benchmem ./...

--- a/highlight.go
+++ b/highlight.go
@@ -5,13 +5,17 @@ package syntaxhighlight
 
 import (
 	"bytes"
+	"html"
 	"io"
+	"strings"
 	"text/scanner"
 	"text/template"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/sourcegraph/annotate"
+	"sourcegraph.com/sourcegraph/go-sourcegraph/sourcegraph"
+	"sourcegraph.com/sourcegraph/vcsstore/vcsclient"
 )
 
 // Kind represents a syntax highlighting kind (class) which will be assigned to tokens.
@@ -115,6 +119,105 @@ func (p HTMLPrinter) Print(w io.Writer, kind Kind, tokText string) error {
 
 type Annotator interface {
 	Annotate(start int, kind Kind, tokText string) (*annotate.Annotation, error)
+}
+
+// NilAnnotator is a special kind of annotator that always returns nil, but stores
+// within itself the snippet of source code that is passed through it as tokens.
+//
+// This functionality is useful when one wishes to obtain the tokenized source as a data
+// structure, as opposed to an annotated string, allowing full control over rendering and
+// displaying it.
+type NilAnnotator struct {
+	Config     HTMLConfig
+	Code       *sourcegraph.SourceCode
+	byteOffset int
+}
+
+func NewNilAnnotator(e *vcsclient.FileWithRange) *NilAnnotator {
+	ann := NilAnnotator{
+		Config: DefaultHTMLConfig,
+		Code: &sourcegraph.SourceCode{
+			Lines: make([]*sourcegraph.SourceCodeLine, 0, bytes.Count(e.Contents, []byte("\n"))),
+		},
+		byteOffset: e.StartByte,
+	}
+	ann.addLine(ann.byteOffset)
+	return &ann
+}
+
+func (a *NilAnnotator) addToken(t interface{}) {
+	line := a.Code.Lines[len(a.Code.Lines)-1]
+	if line.Tokens == nil {
+		line.Tokens = make([]interface{}, 0, 1)
+	}
+	// If this token and the previous one are both strings, merge them.
+	n := len(line.Tokens)
+	if t1, ok := t.(string); ok && n > 0 {
+		if t2, ok := (line.Tokens[n-1]).(string); ok {
+			line.Tokens[n-1] = string(t1 + t2)
+			return
+		}
+	}
+	line.Tokens = append(line.Tokens, t)
+}
+
+func (a *NilAnnotator) addLine(startByte int) {
+	a.Code.Lines = append(a.Code.Lines, &sourcegraph.SourceCodeLine{StartByte: startByte})
+	if len(a.Code.Lines) > 1 {
+		lastLine := a.Code.Lines[len(a.Code.Lines)-2]
+		lastLine.EndByte = startByte - 1
+	}
+}
+
+func (a *NilAnnotator) addMultilineToken(startByte int, unsafeHTML string, class string) {
+	lines := strings.Split(unsafeHTML, "\n")
+	for n, unsafeHTML := range lines {
+		if len(unsafeHTML) > 0 {
+			a.addToken(&sourcegraph.SourceCodeToken{
+				StartByte: startByte,
+				EndByte:   startByte + len(unsafeHTML),
+				Class:     class,
+				Label:     html.EscapeString(unsafeHTML),
+			})
+			startByte += len(unsafeHTML)
+		}
+		if n < len(lines)-1 {
+			a.addLine(startByte)
+		}
+	}
+}
+
+func (a *NilAnnotator) Annotate(start int, kind Kind, tokText string) (*annotate.Annotation, error) {
+	class := ((HTMLConfig)(a.Config)).class(kind)
+	txt := html.EscapeString(tokText)
+	start += a.byteOffset
+
+	switch {
+	// New line
+	case tokText == "\n":
+		a.addLine(start + 1)
+
+	// Whitespace token
+	case class == "":
+		a.addToken(txt)
+
+	// Multiline token (ie. block comments, string literals)
+	case strings.Contains(tokText, "\n"):
+		// Here we pass the unescaped string so we can calculate line lenghts correctly.
+		// This method is expected to take responsibility of escaping any token text.
+		a.addMultilineToken(start+1, tokText, class)
+
+	// Token
+	default:
+		a.addToken(&sourcegraph.SourceCodeToken{
+			StartByte: start,
+			EndByte:   start + len(tokText),
+			Class:     class,
+			Label:     txt,
+		})
+	}
+
+	return nil, nil
 }
 
 type HTMLAnnotator HTMLConfig

--- a/highlight_test.go
+++ b/highlight_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/kr/pretty"
 	"github.com/sourcegraph/annotate"
+	"sourcegraph.com/sourcegraph/go-sourcegraph/sourcegraph"
+	"sourcegraph.com/sourcegraph/vcsstore/vcsclient"
 )
 
 var saveExp = flag.Bool("exp", false, "overwrite all expected output files with actual output (returning a failure)")
@@ -93,6 +95,106 @@ func TestAnnotate(t *testing.T) {
 		t.Errorf("want %# v, got %# v\n\ndiff:\n%v", pretty.Formatter(want), pretty.Formatter(got), strings.Join(pretty.Diff(got, want), "\n"))
 		for _, g := range got {
 			t.Logf("%+v  %q  LEFT=%q RIGHT=%q", g, src[g.Start:g.End], g.Left, g.Right)
+		}
+	}
+}
+
+// codeEquals tests the equality between the given SourceCode entry and an
+// array of lines containing arrays of tokens as their string representation.
+func codeEquals(code *sourcegraph.SourceCode, want [][]string) bool {
+	if len(code.Lines) != len(want) {
+		return false
+	}
+	for i, line := range code.Lines {
+		for j, t := range line.Tokens {
+			switch t := t.(type) {
+			case *sourcegraph.SourceCodeToken:
+				if t.Label != want[i][j] {
+					return false
+				}
+			case string:
+				if t != want[i][j] {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func TestCodeEquals(t *testing.T) {
+	for _, tt := range []struct {
+		code *sourcegraph.SourceCode
+		want [][]string
+	}{
+		{
+			code: &sourcegraph.SourceCode{
+				Lines: []*sourcegraph.SourceCodeLine{
+					&sourcegraph.SourceCodeLine{
+						Tokens: []interface{}{
+							&sourcegraph.SourceCodeToken{Label: "a"},
+							&sourcegraph.SourceCodeToken{Label: "b"},
+							"c",
+							&sourcegraph.SourceCodeToken{Label: "d"},
+							"e",
+						},
+					},
+					&sourcegraph.SourceCodeLine{},
+					&sourcegraph.SourceCodeLine{
+						Tokens: []interface{}{
+							"c",
+						},
+					},
+				},
+			},
+			want: [][]string{[]string{"a", "b", "c", "d", "e"}, []string{}, []string{"c"}},
+		},
+	} {
+		if !codeEquals(tt.code, tt.want) {
+			t.Errorf("Expected: %# v, Got: %# v\n", tt.code, tt.want)
+		}
+	}
+}
+
+func newFileWithRange(src []byte) *vcsclient.FileWithRange {
+	return &vcsclient.FileWithRange{
+		TreeEntry: &vcsclient.TreeEntry{Contents: []byte(src)},
+		FileRange: vcsclient.FileRange{StartByte: 0, EndByte: len(src)},
+	}
+}
+
+func TestNilAnnotator_multiLineTokens(t *testing.T) {
+	for _, tt := range []struct {
+		src  string
+		want [][]string
+	}{
+		{
+			src: "/* I am\na multiline\ncomment\n*/",
+			want: [][]string{
+				[]string{"/* I am"},
+				[]string{"a multiline"},
+				[]string{"comment"},
+				[]string{"*/"},
+			},
+		},
+		{
+			src: "a := `I am\na multiline\nstring literal\n`",
+			want: [][]string{
+				[]string{"a", " ", ":", "=", " ", "`I am"},
+				[]string{"a multiline"},
+				[]string{"string literal"},
+				[]string{"`"},
+			},
+		},
+	} {
+		e := newFileWithRange([]byte(tt.src))
+		ann := NewNilAnnotator(e)
+		_, err := Annotate(e.Contents, ann)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !codeEquals(ann.Code, tt.want) {
+			t.Errorf("Expected %# v\n\nGot %# v", tt.want, pretty.Formatter(ann.Code.Lines))
 		}
 	}
 }


### PR DESCRIPTION
`NilAnnotator` is a special kind of annotator that always returns nil, but stores within itself the snippet of source code that is passed through it as tokens. This functionality is useful when one wishes to obtain the tokenized source as a data structure, as opposed to an annotated string, allowing full control over rendering and displaying it.

I have rebased the `r3.0` branch on top of `master`, resolved merge conflicts, and squashed everything into one commit. All tests pass.

Please review, so we can merge this into `master`. /cc @gbbr