### PR TITLE
Use 'master' instead of 'tip' for Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
-  - tip
+  - master
 install:
   - go get -t -v ./...
 script:


### PR DESCRIPTION
As per comment from 
@shurcooL: https://github.com/sourcegraph/syntaxhighlight/commit/99fca8064a80da6f4b332be95c789dee0c4b73f5#commitcomment-22349331